### PR TITLE
Update the test names to match a regex in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,12 @@ build:
 	  go build ./...
 
 .PHONY: test
-test: test-unit
+test: test-unit test-integration
 
 .PHONY: test-unit
 test-unit:
 	  go test $(TESTS) -run 'Unit' -coverprofile=coverage.out
+
+.PHONY: test-integration
+test-integration:
+	  go test $(TESTS) -run 'Integration'

--- a/gofigure_test.go
+++ b/gofigure_test.go
@@ -143,7 +143,7 @@ type MyConfigFull struct {
 	ArrayStringField []string
 }
 
-func TestParseStruct(t *testing.T) {
+func TestUnitParseStruct(t *testing.T) {
 	Convey("parseStruct should return an error unless given a pointer to a struct", t, func() {
 		info, e := parseStruct(1)
 		So(e, ShouldNotBeNil)
@@ -229,7 +229,7 @@ func TestParseStruct(t *testing.T) {
 	clear()
 }
 
-func TestGofigure(t *testing.T) {
+func TestIntegrationGofigure(t *testing.T) {
 	Convey("Gofigure should set field values", t, func() {
 		os.Clearenv()
 		os.Args = []string{"gofigure", "-bind-addr", "abcdef"}
@@ -290,7 +290,7 @@ func TestGofigure(t *testing.T) {
 	clear()
 }
 
-func TestBoolField(t *testing.T) {
+func TestIntegrationBoolField(t *testing.T) {
 	Convey("Can set a bool field to true (flag)", t, func() {
 		os.Clearenv()
 		os.Args = []string{
@@ -363,7 +363,7 @@ func TestBoolField(t *testing.T) {
 	clear()
 }
 
-func TestIntField(t *testing.T) {
+func TestIntegrationIntField(t *testing.T) {
 	Convey("Can set int fields (flag)", t, func() {
 		os.Clearenv()
 		os.Args = []string{
@@ -471,7 +471,7 @@ func TestIntField(t *testing.T) {
 	clear()
 }
 
-func TestUintField(t *testing.T) {
+func TestIntegrationUintField(t *testing.T) {
 	Convey("Can set uint fields (flag)", t, func() {
 		os.Clearenv()
 		os.Args = []string{
@@ -536,7 +536,7 @@ func TestUintField(t *testing.T) {
 	clear()
 }
 
-func TestArrayField(t *testing.T) {
+func TestIntegrationArrayField(t *testing.T) {
 	Convey("String array should work", t, func() {
 		os.Clearenv()
 		os.Args = []string{

--- a/sources/commandline_test.go
+++ b/sources/commandline_test.go
@@ -6,7 +6,7 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-func TestCamelToFlag(t *testing.T) {
+func TestUnitCamelToFlag(t *testing.T) {
 	Convey("camelToFlag converts CamelCase to flag-case", t, func() {
 		So(camelToFlag("CamelCase"), ShouldEqual, "camel-case")
 		So(camelToFlag("camelCase"), ShouldEqual, "camel-case")

--- a/sources/environment_test.go
+++ b/sources/environment_test.go
@@ -6,7 +6,7 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-func TestCamelToSnake(t *testing.T) {
+func TestUnitCamelToSnake(t *testing.T) {
 	Convey("camelToSnake converts CamelCase to snake_case", t, func() {
 		So(camelToSnake("CamelCase"), ShouldEqual, "CAMEL_CASE")
 		So(camelToSnake("camelCase"), ShouldEqual, "CAMEL_CASE")


### PR DESCRIPTION
The Makefile requires test names to contain "Unit" or "Integration" or they will not be run. This change updates the test names to match the expected regex.